### PR TITLE
更新列出文件接口

### DIFF
--- a/cloud189/cli/cli.py
+++ b/cloud189/cli/cli.py
@@ -78,7 +78,11 @@ class Commander:
     def refresh(self, dir_id=None, auto=False):
         """刷新当前文件夹和路径信息"""
         dir_id = self._work_id if dir_id is None else dir_id
-        self._file_list, self._path_list = self._disk.get_file_list(dir_id)
+
+        if dir_id == -11:
+            self._file_list, self._path_list = self._disk.get_root_file_list()
+        else:
+            self._file_list, self._path_list = self._disk.get_file_list(dir_id)
         if not self._file_list and not self._path_list:
             if auto:
                 error(f"文件夹 id={dir_id} 无效(被删除), 将切换到根目录！")


### PR DESCRIPTION
天翼云接口变动，导致列出目录文件接口失败。  

主要适配新接口进行修改：  

+  更新接口url
+  新接口主要区分了根目录和其它目录，分为两个接口，根目录保持之前响应体，其它目录响应体进行了更新，进行适配  
+  新接口不再提供 pathlist，因此需要手动组装
+  新接口需要请求体指定 Accept 为 Json，否则默认返回 XML  

修改后目录查询以及cd命令跳转正常，如下：
  
![image](https://user-images.githubusercontent.com/1511067/138604148-04698ca7-16b8-4c16-8b27-02b8a9a0439f.png)
